### PR TITLE
Refactor ConfigutionOperation implementations to their own classes

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/EnrichmentConfigurationOperations.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/EnrichmentConfigurationOperations.java
@@ -18,53 +18,27 @@
 
 package org.apache.metron.common.configuration;
 
-import com.google.common.base.Function;
 import java.io.IOException;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.metron.common.configuration.enrichment.SensorEnrichmentConfig;
+import org.apache.metron.common.utils.JSONUtils;
 
-public enum ConfigurationType implements Function<String, Object>, ConfigurationOperations {
+public class EnrichmentConfigurationOperations implements ConfigurationOperations {
 
-  GLOBAL(new GlobalConfigurationOperations()),
-  PARSER(new ParserConfigurationOperations()),
-  ENRICHMENT(new EnrichmentConfigurationOperations()),
-  INDEXING(new IndexingConfigurationOperations()),
-  PROFILER(new ProfilerConfigurationOperations());
-
-  ConfigurationOperations ops;
-
-  ConfigurationType(ConfigurationOperations ops) {
-    this.ops = ops;
-  }
-
+  @Override
   public String getTypeName() {
-    return ops.getTypeName();
-  }
-
-  public String getDirectory() {
-    return ops.getDirectory();
-  }
-
-  public Object deserialize(String s) {
-    try {
-      return ops.deserialize(s);
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to load " + s, e);
-    }
+    return "enrichments";
   }
 
   @Override
-  public Object apply(String s) {
-    return deserialize(s);
+  public Object deserialize(String s) throws IOException {
+    return JSONUtils.INSTANCE.load(s, SensorEnrichmentConfig.class);
   }
 
   @Override
   public void writeSensorConfigToZookeeper(String sensorType, byte[] configData,
       CuratorFramework client) throws Exception {
-    ops.writeSensorConfigToZookeeper(sensorType, configData, client);
-  }
-
-  public String getZookeeperRoot() {
-    return ops.getZookeeperRoot();
+    ConfigurationsUtils.writeSensorEnrichmentConfigToZookeeper(sensorType, configData, client);
   }
 
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/GlobalConfigurationOperations.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/GlobalConfigurationOperations.java
@@ -18,53 +18,34 @@
 
 package org.apache.metron.common.configuration;
 
-import com.google.common.base.Function;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
+import java.util.Map;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.metron.common.utils.JSONUtils;
 
-public enum ConfigurationType implements Function<String, Object>, ConfigurationOperations {
+public class GlobalConfigurationOperations implements ConfigurationOperations {
 
-  GLOBAL(new GlobalConfigurationOperations()),
-  PARSER(new ParserConfigurationOperations()),
-  ENRICHMENT(new EnrichmentConfigurationOperations()),
-  INDEXING(new IndexingConfigurationOperations()),
-  PROFILER(new ProfilerConfigurationOperations());
-
-  ConfigurationOperations ops;
-
-  ConfigurationType(ConfigurationOperations ops) {
-    this.ops = ops;
-  }
-
+  @Override
   public String getTypeName() {
-    return ops.getTypeName();
-  }
-
-  public String getDirectory() {
-    return ops.getDirectory();
-  }
-
-  public Object deserialize(String s) {
-    try {
-      return ops.deserialize(s);
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to load " + s, e);
-    }
+    return "global";
   }
 
   @Override
-  public Object apply(String s) {
-    return deserialize(s);
+  public String getDirectory() {
+    return ".";
+  }
+
+  @Override
+  public Object deserialize(String s) throws IOException {
+    return JSONUtils.INSTANCE.load(s, new TypeReference<Map<String, Object>>() {
+    });
   }
 
   @Override
   public void writeSensorConfigToZookeeper(String sensorType, byte[] configData,
-      CuratorFramework client) throws Exception {
-    ops.writeSensorConfigToZookeeper(sensorType, configData, client);
-  }
-
-  public String getZookeeperRoot() {
-    return ops.getZookeeperRoot();
+      CuratorFramework client) {
+    throw new UnsupportedOperationException("Global configs are not per-sensor");
   }
 
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ParserConfigurationOperations.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ParserConfigurationOperations.java
@@ -18,53 +18,26 @@
 
 package org.apache.metron.common.configuration;
 
-import com.google.common.base.Function;
 import java.io.IOException;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.metron.common.utils.JSONUtils;
 
-public enum ConfigurationType implements Function<String, Object>, ConfigurationOperations {
+public class ParserConfigurationOperations implements ConfigurationOperations {
 
-  GLOBAL(new GlobalConfigurationOperations()),
-  PARSER(new ParserConfigurationOperations()),
-  ENRICHMENT(new EnrichmentConfigurationOperations()),
-  INDEXING(new IndexingConfigurationOperations()),
-  PROFILER(new ProfilerConfigurationOperations());
-
-  ConfigurationOperations ops;
-
-  ConfigurationType(ConfigurationOperations ops) {
-    this.ops = ops;
-  }
-
+  @Override
   public String getTypeName() {
-    return ops.getTypeName();
-  }
-
-  public String getDirectory() {
-    return ops.getDirectory();
-  }
-
-  public Object deserialize(String s) {
-    try {
-      return ops.deserialize(s);
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to load " + s, e);
-    }
+    return "parsers";
   }
 
   @Override
-  public Object apply(String s) {
-    return deserialize(s);
+  public Object deserialize(String s) throws IOException {
+    return JSONUtils.INSTANCE.load(s, SensorParserConfig.class);
   }
 
   @Override
   public void writeSensorConfigToZookeeper(String sensorType, byte[] configData,
       CuratorFramework client) throws Exception {
-    ops.writeSensorConfigToZookeeper(sensorType, configData, client);
-  }
-
-  public String getZookeeperRoot() {
-    return ops.getZookeeperRoot();
+    ConfigurationsUtils.writeSensorParserConfigToZookeeper(sensorType, configData, client);
   }
 
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ProfilerConfigurationOperations.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ProfilerConfigurationOperations.java
@@ -18,53 +18,32 @@
 
 package org.apache.metron.common.configuration;
 
-import com.google.common.base.Function;
 import java.io.IOException;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.metron.common.configuration.profiler.ProfilerConfig;
+import org.apache.metron.common.utils.JSONUtils;
 
-public enum ConfigurationType implements Function<String, Object>, ConfigurationOperations {
+public class ProfilerConfigurationOperations implements ConfigurationOperations {
 
-  GLOBAL(new GlobalConfigurationOperations()),
-  PARSER(new ParserConfigurationOperations()),
-  ENRICHMENT(new EnrichmentConfigurationOperations()),
-  INDEXING(new IndexingConfigurationOperations()),
-  PROFILER(new ProfilerConfigurationOperations());
-
-  ConfigurationOperations ops;
-
-  ConfigurationType(ConfigurationOperations ops) {
-    this.ops = ops;
-  }
-
+  @Override
   public String getTypeName() {
-    return ops.getTypeName();
-  }
-
-  public String getDirectory() {
-    return ops.getDirectory();
-  }
-
-  public Object deserialize(String s) {
-    try {
-      return ops.deserialize(s);
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to load " + s, e);
-    }
+    return "profiler";
   }
 
   @Override
-  public Object apply(String s) {
-    return deserialize(s);
+  public String getDirectory() {
+    return ".";
+  }
+
+  @Override
+  public Object deserialize(String s) throws IOException {
+    return JSONUtils.INSTANCE.load(s, ProfilerConfig.class);
   }
 
   @Override
   public void writeSensorConfigToZookeeper(String sensorType, byte[] configData,
       CuratorFramework client) throws Exception {
-    ops.writeSensorConfigToZookeeper(sensorType, configData, client);
-  }
-
-  public String getZookeeperRoot() {
-    return ops.getZookeeperRoot();
+    throw new UnsupportedOperationException("Profiler configs are not per-sensor");
   }
 
 }


### PR DESCRIPTION
Cleanup your cleanup by extracting the ConfigurationOperations into separate classes.